### PR TITLE
Improve parse_octal validation

### DIFF
--- a/src/microtar.c
+++ b/src/microtar.c
@@ -51,8 +51,8 @@ static int parse_octal(const char* str, size_t len, unsigned* ret)
 {
     unsigned n = 0;
 
-    while(len-- > 0 && *str != 0) {
-        if(*str < '0' || *str > '9')
+    while(len-- > 0 && *str != 0 && *str != ' ') {
+        if(*str < '0' || *str > '7')
             return MTAR_EOVERFLOW;
 
         if(n > UINT_MAX/8)


### PR DESCRIPTION
* Recognise space char as valid termination char (valid within USTAR header)
* Valid octal digits are only 0-7 (not 0-9)